### PR TITLE
Map adjusted

### DIFF
--- a/KartverketProject/Controllers/KartverketController.cs
+++ b/KartverketProject/Controllers/KartverketController.cs
@@ -16,9 +16,10 @@ public class KartverketController : ControllerBase
             ObstacleName = "Tre",
             ObstacleHeight = 2,
             ObstacleDescription = "Et tre ligger her",
-            ObstacleJSON = "[lat = 1337, lang = 1337]",
+            ObstacleJSON = "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[7.994013,58.161083]}},{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Point\",\"coordinates\":[7.999463,58.16114]}},{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[7.994013,58.161083],[7.999463,58.16114]]}}]}"
         }
     };
+
 
     [HttpGet]
     public ActionResult<ObstacleData> GetObstacles()

--- a/KartverketProject/Controllers/ObstacleController.cs
+++ b/KartverketProject/Controllers/ObstacleController.cs
@@ -18,6 +18,9 @@ public ActionResult DataForm()
 [HttpPost]
 public ActionResult DataForm(ObstacleData obstacledata)
 {
-    return View("Overview", obstacledata);
+    if (ModelState.IsValid) { // validering
+        return View("Overview", obstacledata);
+    }
+    return View();
 }
 }

--- a/KartverketProject/KartverketProject.csproj
+++ b/KartverketProject/KartverketProject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>130b79bb-acbf-4362-9eea-514598fa3119</UserSecretsId>
@@ -10,10 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include=".env" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
       <PrivateAssets>all</PrivateAssets>

--- a/KartverketProject/Program.cs
+++ b/KartverketProject/Program.cs
@@ -16,13 +16,17 @@ namespace KartverketProject
             options.UseMySql(builder.Configuration.GetConnectionString("DefaultConnection"),
             new MySqlServerVersion(new Version(11, 8, 3))));
 
+            builder.Services.AddOpenApi();
+
             var app = builder.Build();
+
+            app.MapOpenApi();
+
+            app.MapScalarApiReference();
 
             // Configure the HTTP request pipeline.
             if (!app.Environment.IsDevelopment())
             {
-                app.MapScalarApiReference();
-                //app.MapOpenApi();
                 app.UseExceptionHandler("/Home/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();

--- a/KartverketProject/Views/Obstacle/DataForm.cshtml
+++ b/KartverketProject/Views/Obstacle/DataForm.cshtml
@@ -3,9 +3,9 @@
     ViewData["Title"] = "Register Obstacle";
 }
 
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
+<div id="map"></div>
 
 <section class="mx-auto max-w-2xl">
     <div class="bg-white rounded-2xl shadow-sm ring-1 ring-gray-200 p-6">
@@ -16,6 +16,8 @@
 
         <form asp-action="DataForm" method="post" class="space-y-5">
             <div class="grid gap-5 sm:grid-cols-2">
+
+                <input type="hidden" asp-for="ObstacleJSON" id="ObstacleJSON" />
                 <!-- Obstacle Name -->
                 <div class="sm:col-span-2">
                     <label asp-for="ObstacleName" class="block text-sm font-medium text-gray-800 mb-1">Obstacle Name</label>
@@ -48,8 +50,6 @@
                 </div>
             </div>
 
-            <div id="map"></div>
-
             <div class="pt-2">
                 <button type="submit"
                         class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
@@ -61,6 +61,31 @@
 </section>
 
 @section Scripts {
-    <!-- If you use client-side validation, keep the standard validation partial -->
     <partial name="_ValidationScriptsPartial" />
+    <script>
+        // la layers ver tom
+        let layers = {};
+
+        function updateObstacleJSON() {
+            // layers til string
+            const geoJsonString = JSON.stringify(layers);
+            // ta obstaclejson fra hidden til geojsonstring
+            document.getElementById('ObstacleJSON').value = geoJsonString;
+        }
+
+        // hor etter form submit
+        document.querySelector('form').addEventListener('submit', function (e) {
+            // nor formen blir sendt, oppdater geojsonstring
+            updateObstacleJSON();
+
+            // hent ny deklarering pga funksjonen er utenfor
+            const geoJsonString = document.getElementById('ObstacleJSON').value;
+
+            // hvis tom, stopp brukeren.
+            if(!geoJsonString.length || geoJsonString == '{}') {
+                e.preventDefault();
+                alert("Map requires two markers");
+            }
+        });
+    </script>
 }

--- a/KartverketProject/Views/Obstacle/Overview.cshtml
+++ b/KartverketProject/Views/Obstacle/Overview.cshtml
@@ -4,6 +4,8 @@
     ViewData["Title"] = "Overview";
 }
 
+<div id="map-overview" class="mt-6 rounded-lg border border-gray-300" style="height:400px;"></div>
+
 <section class="mx-auto max-w-2xl">
     <div class="bg-white rounded-2xl shadow-sm ring-1 ring-gray-200 p-6 space-y-4">
         <header>
@@ -12,6 +14,10 @@
         </header>
 
         <dl class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div class="sm:col-span-1">
+                <dt class="text-sm font-medium text-gray-600">Obstacle JSON</dt>
+                <dd class="mt-1 text-base text-gray-900 break-words">@Model.ObstacleJSON</dd>
+            </div>
             <div class="sm:col-span-1">
                 <dt class="text-sm font-medium text-gray-600">Obstacle Name</dt>
                 <dd class="mt-1 text-base text-gray-900 break-words">@Model.ObstacleName</dd>
@@ -34,3 +40,26 @@
         </div>
     </div>
 </section>
+
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script>
+        var map = L.map('map-overview').setView([0, 0], 2);
+        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; OpenStreetMap'
+        }).addTo(map);
+
+        // lag obstaclejson til raw html, ellers null.
+        var geojsonData = @Html.Raw(Model.ObstacleJSON ?? "null");
+
+        // legg til ny kart
+        if (geojsonData) {
+            var layer = L.geoJSON(geojsonData).addTo(map);
+            map.fitBounds(layer.getBounds());
+        } else {
+            console.warn("No geometry data found");
+        }
+    </script>
+}

--- a/KartverketProject/Views/Shared/_Layout.cshtml
+++ b/KartverketProject/Views/Shared/_Layout.cshtml
@@ -21,6 +21,8 @@
     <!-- Your app/site styles if needed -->
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/FirstWebApplication.styles.css" asp-append-version="true" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 </head>
 <body class="min-h-screen flex flex-col bg-gray-50 text-gray-900">
     <!-- Header / Nav -->

--- a/KartverketProject/wwwroot/css/site.css
+++ b/KartverketProject/wwwroot/css/site.css
@@ -35,7 +35,10 @@ body {
     margin: 0;
 }
 
-html, body, #map {
-    height: 100vh;
-    width: 100vw;
+#map {
+    height: 95vh;
+}
+
+nav {
+    height: 5vh;
 }

--- a/KartverketProject/wwwroot/js/map.js
+++ b/KartverketProject/wwwroot/js/map.js
@@ -1,5 +1,6 @@
 var map = L.map('map').fitWorld();
 
+// lag ny kart
 L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     maxZoom: 19,
     attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
@@ -11,6 +12,7 @@ var group = null;
 let checkpoint = false;
 
 map.on('click', function(e) {
+    // hvis allerede satt, fjern alt
     if(checkpoint) {
         map.removeLayer(group);
         points = [];
@@ -18,26 +20,30 @@ map.on('click', function(e) {
         group = null;
         checkpoint = false;
     }
+    // legg til ny marker, og legg de til arrays
     var marker = L.marker(e.latlng).addTo(map);
     markers.push(marker);
     points.push(e.latlng);
 
+    // hvis to markers er satt
     if(points.length == 2) {
         var polyline = L.polyline(points, {color: "red"}).addTo(map);
         group = L.layerGroup([markers[0], markers[1], polyline]).addTo(map);
         checkpoint = true;
+        // lagre til geojson som vi lagrer etterpo i hidden field
         layers = group.toGeoJSON();
-        console.log(layers);
     }
 });
 
+// finn brukers sted
 map.locate({setView: true, maxZoom: 16});
 
 function onLocationFound(e) {
+    // bruker innen stedet
     var radius = e.accuracy;
 
     L.marker(e.latlng).addTo(map)
-        .bindPopup("Du er her").openPopup();
+        .bindPopup("You are here").openPopup();
 
     L.circle(e.latlng, radius).addTo(map);
 }


### PR DESCRIPTION
Previously, the layers were saved into console.log lacking the ObstacleJSON response. Now users can see the obstacleJSON in raw html and the map gets reconstructed on the overview page.

Edit: Using @Html.Raw is a bad idea. This allows XSS. Later fixed with HTML sanitizer, but it makes no sense to sanitize JSON data. It is better to get the model as textContent, DOM parse it as textContent and then parse it as JSON. 